### PR TITLE
add MemesLabTrade parser for Buy, Sell, ListToken events

### DIFF
--- a/parser/createdb.sql
+++ b/parser/createdb.sql
@@ -184,6 +184,12 @@ CREATE TABLE IF NOT EXISTS parsed.memeslab_trade_event (
     created timestamp NULL,
     updated timestamp NULL
 );
+-- add memeslab_trade_event primary key
+BEGIN;
+ALTER TABLE parsed.memeslab_trade_event DROP CONSTRAINT memeslab_trade_event_pkey;
+ALTER TABLE parsed.memeslab_trade_event ADD PRIMARY KEY (tx_hash, event_type);
+COMMIT;
+
 
 -- Adding usd volume for memepads
 ALTER TABLE parsed.gaspump_trade ADD column if not exists "volume_usd" numeric NULL;

--- a/parser/createdb.sql
+++ b/parser/createdb.sql
@@ -168,6 +168,23 @@ CREATE TABLE IF NOT EXISTS parsed.tonfun_bcl_trade (
     updated timestamp NULL
 );
 
+--MemesLab
+CREATE TABLE IF NOT EXISTS parsed.memeslab_trade_event (
+    tx_hash bpchar(44) NULL PRIMARY KEY,
+    trace_id bpchar(44) NULL,
+    event_time int4 NULL,
+    jetton_master varchar NULL,
+    event_type varchar NULL,
+    trader_address varchar NULL,
+    ton_amount numeric NULL,
+    jetton_amount numeric NULL,
+    current_supply numeric NULL,
+    total_ton_collected numeric NULL,
+    volume_usd numeric NULL,
+    created timestamp NULL,
+    updated timestamp NULL
+);
+
 -- Adding usd volume for memepads
 ALTER TABLE parsed.gaspump_trade ADD column if not exists "volume_usd" numeric NULL;
 ALTER TABLE parsed.tonfun_bcl_trade ADD column if not exists "volume_usd" numeric NULL;

--- a/parser/docker-compose.yml
+++ b/parser/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     restart: always
     environment:
       - KAFKA_GROUP_ID=messages_parsers
-      - SUPPORTED_PARSERS=StonfiSwap,StonfiSwapV2,DedustSwap,GasPumpTrade,JettonMintParser,HipoTokensMinted,TonFunTrade,TONCOSwap
+      - SUPPORTED_PARSERS=StonfiSwap,StonfiSwapV2,DedustSwap,GasPumpTrade,JettonMintParser,HipoTokensMinted,TonFunTrade,TONCOSwap,MemesLabTrade
       - KAFKA_TOPICS=ton.public.messages
       - MIN_MATURITY_SECONDS=300
       - RUN_MIGRATIONS=1

--- a/parser/model/memeslab.py
+++ b/parser/model/memeslab.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Optional
+
+
+@dataclass
+class MemesLabEvent:
+    __tablename__ = "memeslab_trade_event"
+    tx_hash: str
+    trace_id: str
+    event_time: int
+    jetton_master: str
+    event_type: str  # Buy, Sell, List
+    trader_address: Optional[str]
+    ton_amount: Optional[Decimal]
+    jetton_amount: Optional[Decimal]
+    volume_usd: Optional[Decimal]
+    current_supply: Decimal  
+    total_ton_collected: Decimal 

--- a/parser/parsers/__init__.py
+++ b/parser/parsers/__init__.py
@@ -18,6 +18,7 @@ from parsers.message.jetton_mint import JettonMintParser, HipoTokensMinted
 from parsers.nft_transfer.nft_history import NftHistoryParser
 from parsers.nft_items.nft_item_metadata import NFTItemMetadataParser
 from parsers.nft_collections.nft_collection_metadata import NFTCollectionMetadataParser
+from parsers.message.memeslab import MemesLabTrade
 from model.parser import Parser
 from loguru import logger
 import os
@@ -38,7 +39,7 @@ _parsers = [
     TonFunTrade(),
     GasPumpTrade(),
     TONCOSwap(),
-    
+    MemesLabTrade(),
     JettonMintParser(),
     HipoTokensMinted(),
 

--- a/parser/parsers/message/memeslab.py
+++ b/parser/parsers/message/memeslab.py
@@ -10,9 +10,9 @@ from parsers.message.swap_volume import USDT
 
 # Opcode mapping for event types
 EVENT_TYPES = {
-    Parser.opcode_signed(0xACE8E777),  # Buy
-    Parser.opcode_signed(0xACE8E778),  # Sell
-    Parser.opcode_signed(0xACE8E779),  # ListToken
+    Parser.opcode_signed(0xace8e777),  # Buy
+    Parser.opcode_signed(0xace8e778),  # Sell
+    Parser.opcode_signed(0xace8e779),  # ListToken
 }
 
 
@@ -20,12 +20,12 @@ def parse_memeslab_event(opcode: int, cs: Cell) -> Optional[dict]:
     try:
         raw_opcode = cs.load_uint(32)  # opcode
 
-        if raw_opcode == 0xACE8E777:  # Buy
+        if raw_opcode == 0xace8e777:  # Buy
             event_type = "Buy"
-        elif raw_opcode == 0xACE8E778:  # Sell
+        elif raw_opcode == 0xace8e778:  # Sell
             event_type = "Sell"
 
-        elif raw_opcode == 0xACE8E779:  # ListToken
+        elif raw_opcode == 0xace8e779:  # ListToken
 
             event_type = "ListToken"
             query_id = cs.load_uint(64)
@@ -56,7 +56,6 @@ def parse_memeslab_event(opcode: int, cs: Cell) -> Optional[dict]:
         token_amount = cs.load_uint(64)  # Jetton in/out
         trader = cs.load_address()  # sender
         cs.load_uint(4)  # reserved (0 or 1)
-
         return {
             "type": event_type,
             "trader": trader,

--- a/parser/parsers/message/memeslab.py
+++ b/parser/parsers/message/memeslab.py
@@ -87,23 +87,6 @@ def make_event(obj: dict, trade_data: dict, price_usd: float) -> MemesLabEvent:
     )
 
 
-def make_event(obj: dict, trade_data: dict, price_usd: float) -> MemesLabEvent:
-
-    return MemesLabEvent(
-        tx_hash=obj["tx_hash"],
-        trace_id=obj["trace_id"],
-        event_time=obj["created_at"],
-        jetton_master=obj["source"],
-        event_type=trade_data["type"],
-        trader_address=trade_data["trader"],
-        ton_amount=int(trade_data["ton_amount"]),
-        jetton_amount=int(trade_data["jetton_amount"]),
-        current_supply=int(trade_data["current_supply"]),
-        total_ton_collected=int(trade_data["total_ton_collected"]),
-        volume_usd=int(trade_data["ton_amount"]) * price_usd / 1e6,
-    )
-
-
 class MemesLabTrade(Parser):
     topics = lambda _: [TOPIC_MESSAGES]
     predicate = lambda _, obj: (

--- a/parser/parsers/message/memeslab.py
+++ b/parser/parsers/message/memeslab.py
@@ -1,0 +1,126 @@
+import traceback
+from typing import Optional
+from decimal import Decimal
+from loguru import logger
+from pytoniq_core import Cell
+from model.parser import NonCriticalParserError, Parser, TOPIC_MESSAGES
+from model.memeslab import MemesLabEvent
+from db import DB
+from parsers.message.swap_volume import USDT
+
+# Opcode mapping for event types
+EVENT_TYPES = {
+    Parser.opcode_signed(0xACE8E777),  # Buy
+    Parser.opcode_signed(0xACE8E778),  # Sell
+    Parser.opcode_signed(0xACE8E779),  # ListToken
+}
+
+
+def parse_memeslab_event(opcode: int, cs: Cell) -> Optional[dict]:
+    try:
+        raw_opcode = cs.load_uint(32)  # opcode
+
+        if raw_opcode == 0xACE8E777:  # Buy
+            event_type = "Buy"
+        elif raw_opcode == 0xACE8E778:  # Sell
+            event_type = "Sell"
+
+        elif raw_opcode == 0xACE8E779:  # ListToken
+
+            event_type = "ListToken"
+            query_id = cs.load_uint(64)
+            pool_complete = cs.load_uint(4)
+            if cs.remaining_bits >= 128:
+                total_ton_collected = cs.load_uint(64)
+                total_supply = cs.load_uint(64)
+            else:
+                total_ton_collected = int(1000 * 1e9)
+                total_supply = int(1000000000 * 1e9)
+            return {
+                "type": event_type,
+                "trader": None,
+                "ton_amount": 0,
+                "jetton_amount": 0,
+                "total_ton_collected": total_ton_collected,
+                "current_supply": total_supply,
+            }
+        else:
+            event_type = "Unknown"  # In case the opcode doesn't match Buy/Sell
+
+        BASE_TOTAL_SUPPLY = int(1000000000 * 1e9)  # 1B in Jettons
+        cs.load_uint(64)  # query_id
+        real_base_reserve = cs.load_uint(64)  # real_base_reserves
+        total_ton_collected = cs.load_uint(64)  # real_quote_reserves
+        current_supply = BASE_TOTAL_SUPPLY - real_base_reserve
+        ton_amount = cs.load_uint(64)  # TON in
+        token_amount = cs.load_uint(64)  # Jetton in/out
+        trader = cs.load_address()  # sender
+        cs.load_uint(4)  # reserved (0 or 1)
+
+        return {
+            "type": event_type,
+            "trader": trader,
+            "ton_amount": ton_amount,
+            "jetton_amount": token_amount,
+            "current_supply": current_supply,
+            "total_ton_collected": total_ton_collected,
+        }
+    except Exception as e:
+        logger.error(f"Error parsing event: {e}")
+        return None
+
+
+def make_event(obj: dict, trade_data: dict, price_usd: float) -> MemesLabEvent:
+
+    return MemesLabEvent(
+        tx_hash=obj["tx_hash"],
+        trace_id=obj["trace_id"],
+        event_time=obj["created_at"],
+        jetton_master=obj["source"],
+        event_type=trade_data["type"],
+        trader_address=trade_data["trader"],
+        ton_amount=int(trade_data["ton_amount"]),
+        jetton_amount=int(trade_data["jetton_amount"]),
+        current_supply=int(trade_data["current_supply"]),
+        total_ton_collected=int(trade_data["total_ton_collected"]),
+        volume_usd=int(trade_data["ton_amount"]) * price_usd / 1e6,
+    )
+
+
+def make_event(obj: dict, trade_data: dict, price_usd: float) -> MemesLabEvent:
+
+    return MemesLabEvent(
+        tx_hash=obj["tx_hash"],
+        trace_id=obj["trace_id"],
+        event_time=obj["created_at"],
+        jetton_master=obj["source"],
+        event_type=trade_data["type"],
+        trader_address=trade_data["trader"],
+        ton_amount=int(trade_data["ton_amount"]),
+        jetton_amount=int(trade_data["jetton_amount"]),
+        current_supply=int(trade_data["current_supply"]),
+        total_ton_collected=int(trade_data["total_ton_collected"]),
+        volume_usd=int(trade_data["ton_amount"]) * price_usd / 1e6,
+    )
+
+
+class MemesLabTrade(Parser):
+    topics = lambda _: [TOPIC_MESSAGES]
+    predicate = lambda _, obj: (
+        obj.get("opcode") in EVENT_TYPES and obj.get("direction") == "out"
+    )
+
+    def handle_internal(self, obj: dict, db: DB) -> None:
+        try:
+            cs = Parser.message_body(obj, db).begin_parse()
+            trade_data = parse_memeslab_event(obj.get("opcode"), cs)
+            if trade_data:
+                ton_price = db.get_core_price(
+                    USDT, Parser.require(obj.get("created_at"))
+                )
+                ton_price = ton_price or 0
+                event = make_event(obj, trade_data, ton_price)
+                db.serialize(event)
+        except Exception as e:
+            logger.error(f"MemesLab parse error: {e}\n{traceback.format_exc()}")
+            raise NonCriticalParserError(f"MemesLab parse error: {e}") from e


### PR DESCRIPTION
This pull request adds support for parsing **MemesLab** contract events on the TON blockchain, specifically:

Mapping Events
1. **Buy (0xACE8E777)**
2. **Sell (0xACE8E778)**
3. **ListToken (0xACE8E779)**

**Key Changes**
1. Created `**memeslab_trade_event**` table schema in PostgreSQL.
2. Added `**MemesLabEvent**` dataclass to model parsed trade events.
3. Implemented `**MemesLabTrade**` parser to extract relevant data from event payloads.
4. Registered the parser in the main parser registry and docker-compose setup.