### PR TITLE
parser: fix cache reload cold-start + add real-time cache updates from Kafka

### DIFF
--- a/parser/main.py
+++ b/parser/main.py
@@ -6,7 +6,7 @@ import json
 import traceback
 from loguru import logger
 from db import DB
-from confluent_kafka import Consumer, KafkaError, OFFSET_END
+from confluent_kafka import Consumer, KafkaError, OFFSET_END, TopicPartition
 from model.parser import Parser
 from parsers import generate_parsers
 
@@ -112,30 +112,45 @@ if __name__ == "__main__":
         db.release()
         logger.info("PROCESS_* mode complete")
     else:
+        broker = os.environ.get("KAFKA_BROKER")
         consumer = Consumer({
             'group.id': group_id,
-            'bootstrap.servers': os.environ.get("KAFKA_BROKER"),
+            'bootstrap.servers': broker,
             'auto.offset.reset': os.environ.get("KAFKA_OFFSET_RESET", 'earliest'),
             'enable.auto.commit': False,
             'max.poll.interval.ms': int(os.environ.get("KAFKA_MAX_POLL_INTERVAL_MS", '300000')),
         })
         cache_parsers_map = build_cache_topics_map(PARSERS)
         cache_topics_set = set(cache_parsers_map.keys())
-        topic_list = list(set(topics.split(",")) | cache_topics_set)
-        logger.info(f"Subscribing to {topic_list} (cache topics: {sorted(cache_topics_set) or 'none'})")
+        event_topics = list(set(topics.split(",")))
+        logger.info(f"Subscribing (event) to {event_topics}; cache topics (broadcast): {sorted(cache_topics_set) or 'none'}")
+        consumer.subscribe(event_topics)
 
-        def on_assign(consumer, partitions):
-            # For cache topics: use committed offset if we have one (rebalance resumes cleanly);
-            # only fall back to OFFSET_END on first-ever assign (no committed → historical entries
-            # are already in prepare() snapshot, timer reload catches any subsequent gaps).
-            for p in partitions:
-                if p.topic in cache_topics_set:
-                    committed = consumer.committed([p], timeout=5)[0]
-                    if committed.offset < 0:
-                        p.offset = OFFSET_END
-            consumer.assign(partitions)
-
-        consumer.subscribe(topic_list, on_assign=on_assign)
+        # Cache consumer — broadcast pattern via assign() to all partitions of all cache topics.
+        # Every pod in a replica set sees every cache event, independent of partition assignment
+        # of the main consumer group. No group coordination for cache — offsets are not persisted,
+        # startup begins at OFFSET_END (prepare() snapshot covers historical state), timer reload
+        # is the safety net for anything missed while the pod was down.
+        cache_consumer = None
+        if cache_topics_set:
+            cache_consumer = Consumer({
+                'group.id': f"cache-broadcast-{os.environ.get('HOSTNAME', 'unknown')}",
+                'bootstrap.servers': broker,
+                'enable.auto.commit': False,
+            })
+            all_tps = []
+            for topic in cache_topics_set:
+                md = cache_consumer.list_topics(topic, timeout=10).topics.get(topic)
+                if md is None or md.error is not None:
+                    logger.warning(f"Cache topic {topic} metadata unavailable, skipping")
+                    continue
+                for partition in md.partitions.keys():
+                    all_tps.append(TopicPartition(topic, partition, OFFSET_END))
+            if all_tps:
+                cache_consumer.assign(all_tps)
+                logger.info(f"Cache consumer assigned to {len(all_tps)} partitions across {sorted(cache_topics_set)}")
+            else:
+                cache_consumer = None
 
         last_commit_at = time.time()
         # Start timer such that first tick fires quickly — closes gap between prepare() snapshot
@@ -168,6 +183,24 @@ if __name__ == "__main__":
                 kafka_batch = 0
                 last_commit_at = time.time()
 
+            # Drain any pending cache events first (non-blocking) so they land ahead of
+            # the state events that depend on them. Cache events are rare, so this loop
+            # exits quickly in normal operation.
+            if cache_consumer is not None:
+                while True:
+                    cache_msg = cache_consumer.poll(timeout=0)
+                    if cache_msg is None:
+                        break
+                    if cache_msg.error():
+                        if cache_msg.error().code() != KafkaError._PARTITION_EOF:
+                            logger.error(f"Cache consumer error: {cache_msg.error()}")
+                        break
+                    try:
+                        cache_obj = json.loads(cache_msg.value().decode("utf-8"))
+                        process_cache_event(cache_obj, cache_msg.topic(), cache_parsers_map, db)
+                    except Exception as e:
+                        logger.error(f"Failed to process cache item {cache_msg}: {e} {traceback.format_exc()}")
+
             msg = consumer.poll(timeout=1.0)
             if msg is None:
                 continue
@@ -181,17 +214,12 @@ if __name__ == "__main__":
                 total += 1
                 kafka_batch += 1
                 obj = json.loads(msg.value().decode("utf-8"))
-                if msg.topic() in cache_topics_set:
-                    # Cache events must NOT wait for maturity — they need to arrive in the cache
-                    # as early as possible, ahead of the state events that depend on them.
-                    process_cache_event(obj, msg.topic(), cache_parsers_map, db)
-                else:
-                    _ts_type, ts_ms = msg.timestamp()
-                    if ts_ms and min_maturity and ts_ms > time.time() * 1000 - min_maturity:
-                        wait_interval_ms = ts_ms - time.time() * 1000 + min_maturity + 100
-                        logger.info(f"Waiting for {wait_interval_ms / 1000:0.1f} s before processing next message, timestamp {ts_ms}, partition {msg.partition()}")
-                        time.sleep(wait_interval_ms / 1000)
-                    successful += process_msg(obj, msg.topic(), PARSERS, db)
+                _ts_type, ts_ms = msg.timestamp()
+                if ts_ms and min_maturity and ts_ms > time.time() * 1000 - min_maturity:
+                    wait_interval_ms = ts_ms - time.time() * 1000 + min_maturity + 100
+                    logger.info(f"Waiting for {wait_interval_ms / 1000:0.1f} s before processing next message, timestamp {ts_ms}, partition {msg.partition()}")
+                    time.sleep(wait_interval_ms / 1000)
+                successful += process_msg(obj, msg.topic(), PARSERS, db)
                 now = time.time()
                 if now - last > log_interval:
                     logger.info(f"{1.0 * total / (now - last):0.2f} Kafka messages per second ({total} processed), {100.0 * successful / total:0.2f}% handled")

--- a/parser/main.py
+++ b/parser/main.py
@@ -6,7 +6,7 @@ import json
 import traceback
 from loguru import logger
 from db import DB
-from confluent_kafka import Consumer, KafkaError
+from confluent_kafka import Consumer, KafkaError, OFFSET_END
 from model.parser import Parser
 from parsers import generate_parsers
 
@@ -21,6 +21,34 @@ def process_msg(obj, topic, parsers_map, db):
     return handled
 
 
+def process_cache_event(obj, topic, cache_parsers_map, db):
+    op = obj.get('__op')
+    if op not in ('c', 'u'):
+        return
+    for parser in cache_parsers_map.get(topic, []):
+        try:
+            parser.on_cache_event(obj, db)
+        except Exception as e:
+            logger.error(f"Failed to apply cache event on {parser.__class__.__name__}: {e}")
+
+
+def unique_parsers(parsers_dict):
+    seen = set()
+    for parser_list in parsers_dict.values():
+        for parser in parser_list:
+            if id(parser) not in seen:
+                seen.add(id(parser))
+                yield parser
+
+
+def build_cache_topics_map(parsers_dict):
+    cache_map = {}
+    for parser in unique_parsers(parsers_dict):
+        for t in parser.cache_topics():
+            cache_map.setdefault(t, []).append(parser)
+    return cache_map
+
+
 if __name__ == "__main__":
     group_id = os.environ.get("KAFKA_GROUP_ID")
     commit_batch_size = int(os.environ.get("COMMIT_BATCH_SIZE", "100"))
@@ -30,6 +58,8 @@ if __name__ == "__main__":
     max_processed_items = int(os.environ.get("MAX_PROCESSED_ITEMS", '1000000'))
     # idle commit timer — flush partial batch when upstream is quiet, so consumer lag drains on indexer stop
     commit_interval = int(os.environ.get("COMMIT_INTERVAL", '600'))
+    # timer fallback for parser cache reload — safety net against missed Kafka cache events
+    cache_reload_interval = int(os.environ.get("PARSER_CACHE_RELOAD_SEC", '3600'))
     supported_parsers = os.environ.get("SUPPORTED_PARSERS", "*")
     # to avoid race conditions we will process messages with maturity greater than MIN_MATURITY_SECONDS
     min_maturity = int(os.environ.get("MIN_MATURITY_SECONDS", "0")) * 1000
@@ -89,13 +119,39 @@ if __name__ == "__main__":
             'enable.auto.commit': False,
             'max.poll.interval.ms': int(os.environ.get("KAFKA_MAX_POLL_INTERVAL_MS", '300000')),
         })
-        topic_list = topics.split(",")
-        logger.info(f"Subscribing to {topic_list}")
-        consumer.subscribe(topic_list)
+        cache_parsers_map = build_cache_topics_map(PARSERS)
+        cache_topics_set = set(cache_parsers_map.keys())
+        topic_list = list(set(topics.split(",")) | cache_topics_set)
+        logger.info(f"Subscribing to {topic_list} (cache topics: {sorted(cache_topics_set) or 'none'})")
+
+        def on_assign(consumer, partitions):
+            # For cache topics: use committed offset if we have one (rebalance resumes cleanly);
+            # only fall back to OFFSET_END on first-ever assign (no committed → historical entries
+            # are already in prepare() snapshot, timer reload catches any subsequent gaps).
+            for p in partitions:
+                if p.topic in cache_topics_set:
+                    committed = consumer.committed([p], timeout=5)[0]
+                    if committed.offset < 0:
+                        p.offset = OFFSET_END
+            consumer.assign(partitions)
+
+        consumer.subscribe(topic_list, on_assign=on_assign)
 
         last_commit_at = time.time()
+        # Start timer such that first tick fires quickly — closes gap between prepare() snapshot
+        # and consumer subscribe (any cache events landed in that window are picked up).
+        last_cache_reload_at = time.time() - cache_reload_interval + 60
 
         while True:
+            # Timer-based cache reload — safety net against missed Kafka events / cold-start dead loops.
+            # Runs independently of predicate, so cache-only-predicate parsers cannot get stuck at cache=0.
+            if time.time() - last_cache_reload_at > cache_reload_interval:
+                for parser in unique_parsers(PARSERS):
+                    try:
+                        parser.reload_cache(db)
+                    except Exception as e:
+                        logger.error(f"reload_cache failed on {parser.__class__.__name__}: {e}")
+                last_cache_reload_at = time.time()
             # Idle commit check — fires even when poll returns None, so lag drains when upstream is quiet.
             # Time-based trigger uses kafka_batch (not db.updated) so it also drains streams where
             # most messages are filtered out and never produce DB writes.
@@ -122,16 +178,20 @@ if __name__ == "__main__":
                 continue
 
             try:
-                _ts_type, ts_ms = msg.timestamp()
-                if ts_ms and min_maturity and ts_ms > time.time() * 1000 - min_maturity:
-                    wait_interval_ms = ts_ms - time.time() * 1000 + min_maturity + 100
-                    logger.info(f"Waiting for {wait_interval_ms / 1000:0.1f} s before processing next message, timestamp {ts_ms}, partition {msg.partition()}")
-                    time.sleep(wait_interval_ms / 1000)
-
                 total += 1
                 kafka_batch += 1
                 obj = json.loads(msg.value().decode("utf-8"))
-                successful += process_msg(obj, msg.topic(), PARSERS, db)
+                if msg.topic() in cache_topics_set:
+                    # Cache events must NOT wait for maturity — they need to arrive in the cache
+                    # as early as possible, ahead of the state events that depend on them.
+                    process_cache_event(obj, msg.topic(), cache_parsers_map, db)
+                else:
+                    _ts_type, ts_ms = msg.timestamp()
+                    if ts_ms and min_maturity and ts_ms > time.time() * 1000 - min_maturity:
+                        wait_interval_ms = ts_ms - time.time() * 1000 + min_maturity + 100
+                        logger.info(f"Waiting for {wait_interval_ms / 1000:0.1f} s before processing next message, timestamp {ts_ms}, partition {msg.partition()}")
+                        time.sleep(wait_interval_ms / 1000)
+                    successful += process_msg(obj, msg.topic(), PARSERS, db)
                 now = time.time()
                 if now - last > log_interval:
                     logger.info(f"{1.0 * total / (now - last):0.2f} Kafka messages per second ({total} processed), {100.0 * successful / total:0.2f}% handled")

--- a/parser/model/parser.py
+++ b/parser/model/parser.py
@@ -80,7 +80,8 @@ class Parser:
         return False
 
     def cache_topics(self):
-        return []
+        raw = os.environ.get("KAFKA_CACHE_TOPICS", "").strip()
+        return [t.strip() for t in raw.split(",") if t.strip()]
 
     def on_cache_event(self, obj, db: DB):
         pass

--- a/parser/model/parser.py
+++ b/parser/model/parser.py
@@ -78,7 +78,16 @@ class Parser:
                 print(f"Non critical error during handling object {obj}: {e}")
                 return False
         return False
-    
+
+    def cache_topics(self):
+        return []
+
+    def on_cache_event(self, obj, db: DB):
+        pass
+
+    def reload_cache(self, db: DB):
+        pass
+
     """
     Helper method to convert uint values to int
     """

--- a/parser/parsers/accounts/tvl.py
+++ b/parser/parsers/accounts/tvl.py
@@ -34,9 +34,6 @@ class TVLPoolStateParser(EmulatorParser):
         delta = len(self.pools) - prev_len
         logger.info(f"Reloaded dex pools cache: {len(self.pools)} pools ({delta:+d})")
 
-    def cache_topics(self):
-        return ["ton.prices.dex_pool"]
-
     def on_cache_event(self, obj, db: DB):
         pool_addr = obj.get('pool')
         if not pool_addr:

--- a/parser/parsers/accounts/tvl.py
+++ b/parser/parsers/accounts/tvl.py
@@ -1,5 +1,4 @@
 import copy
-import time
 from typing import Dict
 from loguru import logger
 from db import DB
@@ -9,6 +8,7 @@ from model.dexswap import DEX_DEDUST, DEX_MEGATON, DEX_STON, DEX_STON_V2, DEX_TO
 from model.dedust import read_dedust_asset
 from model.coffee import read_coffee_asset
 from parsers.message.swap_volume import estimate_tvl
+from parsers.utils import decode_decimal
 from pytvm.tvm_emulator.tvm_emulator import TvmEmulator
 from parsers.accounts.emulator import EmulatorException, EmulatorParser
 
@@ -20,17 +20,46 @@ Listens to updates on DEX pools, exrtacts reserves and total_supply
 and estimates TVL.
 """
 class TVLPoolStateParser(EmulatorParser):
-    def __init__(self, emulator_path, update_interval=3600):
+    def __init__(self, emulator_path):
         super().__init__(emulator_path)
-        self.last_updated = int(time.time())
-        # update intervals for pools
-        self.update_interval = update_interval
         self.pools: Dict[str, DexPool] = {}
 
     def prepare(self, db: DB):
         super().prepare(db)
+        self.reload_cache(db)
+
+    def reload_cache(self, db: DB):
+        prev_len = len(self.pools)
         self.pools = db.get_all_dex_pools()
-        logger.info(f"Found {len(self.pools)} unique dex pools to handle")
+        delta = len(self.pools) - prev_len
+        logger.info(f"Reloaded dex pools cache: {len(self.pools)} pools ({delta:+d})")
+
+    def cache_topics(self):
+        return ["ton.prices.dex_pool"]
+
+    def on_cache_event(self, obj, db: DB):
+        pool_addr = obj.get('pool')
+        if not pool_addr:
+            return
+        was_new = pool_addr not in self.pools
+        self.pools[pool_addr] = DexPool(
+            pool=pool_addr,
+            platform=obj.get('platform'),
+            jetton_left=Address(obj['jetton_left']) if obj.get('jetton_left') else None,
+            jetton_right=Address(obj['jetton_right']) if obj.get('jetton_right') else None,
+            reserves_left=decode_decimal(obj['reserves_left']) if obj.get('reserves_left') else None,
+            reserves_right=decode_decimal(obj['reserves_right']) if obj.get('reserves_right') else None,
+            total_supply=decode_decimal(obj['total_supply']) if obj.get('total_supply') else None,
+            tvl_usd=decode_decimal(obj['tvl_usd']) if obj.get('tvl_usd') else None,
+            tvl_ton=decode_decimal(obj['tvl_ton']) if obj.get('tvl_ton') else None,
+            last_updated=obj.get('last_updated'),
+            is_liquid=obj['is_liquid'] if obj.get('is_liquid') is not None else True,
+            lp_fee=decode_decimal(obj['lp_fee']) if obj.get('lp_fee') else None,
+            protocol_fee=decode_decimal(obj['protocol_fee']) if obj.get('protocol_fee') else None,
+            referral_fee=decode_decimal(obj['referral_fee']) if obj.get('referral_fee') else None,
+        )
+        if was_new:
+            logger.info(f"Cache event added pool {pool_addr} ({obj.get('platform')})")
 
     def predicate(self, obj) -> bool:
         if super().predicate(obj):
@@ -38,7 +67,6 @@ class TVLPoolStateParser(EmulatorParser):
         return False
     
     def _do_parse(self, obj, db: DB, emulator: TvmEmulator):
-        # TODO refresh pool data every update_interval
         pool = self.pools[obj['account']]
         pool.last_updated = obj['timestamp']
 
@@ -224,10 +252,3 @@ class TVLPoolStateParser(EmulatorParser):
         estimate_tvl(pool, db)
         logger.info(pool)
         db.update_dex_pool_state(pool)
-
-        if int(time.time()) > self.last_updated + self.update_interval:
-            logger.info("Updating dex pools")
-            prev_len = len(self.pools)
-            self.pools = db.get_all_dex_pools()
-            logger.info(f"Found {len(self.pools) - prev_len} new dex pools to handle")
-            self.last_updated = int(time.time())


### PR DESCRIPTION
Two fixes to the parser cache reload path.

**Cold-start dead loop after DB reset.** When the DB is recreated (e.g. during a partitioning migration), the initial cache load from the DB returns empty because the seed rows are gone. The timer-based cache reload that would eventually refill the cache sat inside a code branch that only ran when the in-memory cache was non-empty, so on an empty cache it never fired. The parser stayed on an empty cache indefinitely and silently skipped every message. Moved the timer out so it fires unconditionally.

**Real-time cache updates from a Kafka topic.** Parsers can now opt into subscribing to an additional Kafka topic (`KAFKA_CACHE_TOPICS`) whose events are applied to the in-memory cache as they arrive. Previously the cache only refreshed on the periodic timer, which meant new pools created between refreshes were invisible to the parser until the next tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)