### PR TITLE
parser: bound emulator lite-client calls with a 30s timeout

### DIFF
--- a/parser/parsers/accounts/emulator.py
+++ b/parser/parsers/accounts/emulator.py
@@ -34,7 +34,7 @@ class ConfigCellHolder:
     def get(self):
         if getattr(self, '_CONFIG_CELL', None) is None:
             logger.info("Initing config cell from the blockchain")
-            asyncio.run(self._get_cell())
+            asyncio.run(asyncio.wait_for(self._get_cell(), timeout=30))
             logger.info("Config cell initialized")
         return self._CONFIG_CELL
     
@@ -139,7 +139,7 @@ class EmulatorParser(Parser):
             missing_library = result['missing_library']
 
             logger.warning(f"Got missing library {missing_library}: {result}")
-            lib = asyncio.run(self.get_lib(missing_library))
+            lib = asyncio.run(asyncio.wait_for(self.get_lib(missing_library), timeout=30))
             if not lib:
                 logger.error(f"Failed to get library {missing_library}")
                 raise EmulatorException(f"Library {missing_library} not found")


### PR DESCRIPTION
Two `asyncio.run` sites in the emulator parser call `pytoniq` LiteClient methods (`client.connect()` at cold start, `get_libraries()` on missing-library recovery). Neither wraps its post-handshake TL requests in `asyncio.wait_for`. When the configured liteserver stops responding — accepts TCP but drops replies — the main poll loop hangs indefinitely. Ten minutes later librdkafka fires MAXPOLL and boots the consumer out of the group, but the parser thread stays stuck for hours until OOM finally restarts the pod. Result: ~11 hours between the stuck liteserver and the pod actually recovering.

Wrap both sites in `asyncio.wait_for(..., timeout=30)`. A stuck liteserver now raises `asyncio.TimeoutError` after 30 seconds; the main loop's `except Exception` logs and re-raises, K8s restarts the pod in ~30-60s, and Kafka retries the message idempotently.

30s is generous — a healthy liteserver replies in <1s, so the timeout only kicks in when the server is truly unresponsive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)