### PR TITLE
parser+datalake: log kafka message payload on processing failure

### DIFF
--- a/datalake/main.py
+++ b/datalake/main.py
@@ -230,7 +230,7 @@ class DatalakeWriter:
                         continue
 
             except Exception as e:
-                logger.error(f"Failted to process item {msg}: {e} {traceback.format_exc()}")
+                logger.error(f"Failed to process item {msg.topic()}:{msg.partition()}:{msg.offset()} {msg.value()}: {e} {traceback.format_exc()}")
                 raise
 
 

--- a/datalake/streaming.py
+++ b/datalake/streaming.py
@@ -178,7 +178,7 @@ class StreamWriter:
                             total = 0
 
             except Exception as e:
-                logger.error(f"Failed to process item {msg}: {e} {traceback.format_exc()}")
+                logger.error(f"Failed to process item {msg.topic()}:{msg.partition()}:{msg.offset()} {msg.value()}: {e} {traceback.format_exc()}")
                 raise
 
         logger.info("Shutdown: final producer flush + consumer commit")

--- a/parser/main.py
+++ b/parser/main.py
@@ -199,7 +199,7 @@ if __name__ == "__main__":
                         cache_obj = json.loads(cache_msg.value().decode("utf-8"))
                         process_cache_event(cache_obj, cache_msg.topic(), cache_parsers_map, db)
                     except Exception as e:
-                        logger.error(f"Failed to process cache item {cache_msg}: {e} {traceback.format_exc()}")
+                        logger.error(f"Failed to process cache item {cache_msg.topic()}:{cache_msg.partition()}:{cache_msg.offset()} {cache_msg.value()}: {e} {traceback.format_exc()}")
 
             msg = consumer.poll(timeout=1.0)
             if msg is None:
@@ -227,5 +227,5 @@ if __name__ == "__main__":
                     successful = 0
                     total = 0
             except Exception as e:
-                logger.error(f"Failed to process item {msg}: {e} {traceback.format_exc()}")
+                logger.error(f"Failed to process item {msg.topic()}:{msg.partition()}:{msg.offset()} {msg.value()}: {e} {traceback.format_exc()}")
                 raise


### PR DESCRIPTION
Message repr became useless after the confluent-kafka migration (7a0e4fc): kafka-python ConsumerRecord was a namedtuple printing the whole record, cimpl.Message is a C type without __repr__, so poison messages were logged as <cimpl.Message object at 0x...> with no way to tell which one failed. Log topic:partition:offset and the raw value instead.