### PR TITLE
parser: treat addr_none from get_nft_address_by_index as a mismatch

### DIFF
--- a/parser/parsers/accounts/nfts_parser.py
+++ b/parser/parsers/accounts/nfts_parser.py
@@ -163,7 +163,7 @@ class NFTItemsParser(EmulatorParser):
                 return
             original_address, = self._execute_method(collection_emulator, 'get_nft_address_by_index', [index], db, obj)
             original_address = original_address.load_address()
-            if original_address != nft_address:
+            if original_address is None or original_address != nft_address:
                 logger.warning(f"NFT address mismatch: {original_address} != {nft_address}")
                 return
             if collection_address == self.TON_DNS:

--- a/parser/parsers/accounts/nfts_recover.py
+++ b/parser/parsers/accounts/nfts_recover.py
@@ -57,7 +57,7 @@ class NFTsRecover(EmulatorParser):
             
             original_address, = self._execute_method(collection_emulator, 'get_nft_address_by_index', [index], db, obj)
             original_address = original_address.load_address()
-            if original_address != nft_address:
+            if original_address is None or original_address != nft_address:
                 logger.warning(f"NFT address mismatch: {original_address} != {nft_address}")
                 return
 


### PR DESCRIPTION
A collection may answer get_nft_address_by_index with addr_none, which load_address() turns into None. Comparing that to an Address hands None to pytoniq_core's Address.__eq__, which dereferences other.wc and raises AttributeError — an unhandled exception that killed the parser process and put parser-nft-items-parser into CrashLoopBackOff.

Semantically an empty answer means the collection did not confirm the item, same verdict as an address that does not match, so route it into the existing mismatch branch.