### PR TITLE
parser: switch pytvm to fork with emulator response strdup fix

### DIFF
--- a/parser/requirements.txt
+++ b/parser/requirements.txt
@@ -2,6 +2,6 @@ confluent-kafka==2.5.3
 loguru==0.6.0
 psycopg2==2.9.9
 pytoniq-core==0.1.37
-git+https://github.com/shuva10v/pytvm.git
+git+https://github.com/aleksandrkaekhtin/pytvm.git
 pytoniq==0.1.39
 requests==2.32.3


### PR DESCRIPTION
Points at aleksandrkaekhtin/pytvm, which routes emulator response strings through string_destroy() so the strdup'd JSON blobs are actually freed. Fixes ~5 MB per minute RSS growth in emulator-based parsers, which caused the ~15h OOM cycle in parser-dex-tvl-parsing, parser-nft-items-parser and the DEX message-swap parsers.
